### PR TITLE
Enhance Hashtag Web Search with dual-space URL termination

### DIFF
--- a/src/lib/components/chat/MessageInput/Documents.svelte
+++ b/src/lib/components/chat/MessageInput/Documents.svelte
@@ -80,7 +80,7 @@
 	const confirmSelectWeb = async (url) => {
 		dispatch('url', url);
 
-		prompt = removeFirstHashWord(prompt);
+		prompt = removeFirstHashWord(prompt.replace(url, '')).trim();
 		const chatInputElement = document.getElementById('chat-textarea');
 
 		await tick();
@@ -132,12 +132,12 @@
 						</button>
 					{/each}
 
-					{#if prompt.split(' ')?.at(0)?.substring(1).startsWith('http')}
+					{#if prompt.split(/ {2,}/)?.at(0)?.substring(1).startsWith('http')}
 						<button
 							class="px-3 py-1.5 rounded-xl w-full text-left bg-gray-100 selected-command-option-button"
 							type="button"
 							on:click={() => {
-								const url = prompt.split(' ')?.at(0)?.substring(1);
+								const url = prompt.split(/ {2,}/)?.at(0)?.substring(1);
 								if (isValidHttpUrl(url)) {
 									confirmSelectWeb(url);
 								} else {
@@ -150,7 +150,7 @@
 							}}
 						>
 							<div class=" font-medium text-black line-clamp-1">
-								{prompt.split(' ')?.at(0)?.substring(1)}
+								{prompt.split(/ {2,}/)?.at(0)?.substring(1)}
 							</div>
 
 							<div class=" text-xs text-gray-600 line-clamp-1">{$i18n.t('Web')}</div>


### PR DESCRIPTION
## Description

Fixed an issue within the Hashtag Web Search functionality where a single space character would incorrectly conclude URL entry, disrupting the user's search experience. The solution implemented requires users to press the space bar twice to signal the end of URL input, enhancing usability by accommodating URLs that contain spaces.

![web-search](https://github.com/open-webui/open-webui/assets/2045117/67acd4ff-1856-4493-9f7a-cb99ac089527)

---

### Changelog Entry

### Added

- None

### Fixed

- Corrected the behavior in Hashtag Web Search where a single space would prematurely end URL entry. Users now need to press the space bar twice to finish entering a URL.

### Changed
src/lib/components/chat/MessageInput.svelte
src/lib/components/chat/MessageInput/Documents.svelte
### Removed
- None
